### PR TITLE
Feast 0.26.0 support

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,8 +1,9 @@
 # This is an example feature definition file
 
-from google.protobuf.duration_pb2 import Duration
+import datetime
 
-from feast import Entity, Feature, FeatureView, ValueType
+from feast import Entity, FeatureView, Field, ValueType
+from feast.types import PrimitiveFeastType
 from feast_hive import HiveSource
 
 # Read data from Hive table
@@ -10,30 +11,31 @@ from feast_hive import HiveSource
 # but you can replace to your own Table or Query.
 driver_hourly_stats = HiveSource(
     # table='driver_stats',
-    query = """
+    query="""
     SELECT from_unixtime(cast(event_timestamp / 1000000 as bigint)) AS event_timestamp, 
            driver_id, conv_rate, acc_rate, avg_daily_trips, 
            from_unixtime(cast(created / 1000000 as bigint)) AS created 
     FROM driver_stats
     """,
-    event_timestamp_column="event_timestamp",
+    name="driver_stats",
+    timestamp_field="event_timestamp",
     created_timestamp_column="created",
 )
 
 # Define an entity for the driver.
-driver = Entity(name="driver_id", value_type=ValueType.INT64, description="driver id", )
+driver = Entity(name="driver_id", join_keys=["driver_id"], value_type=ValueType.INT64, description="driver id", )
 
 # Define FeatureView
 driver_hourly_stats_view = FeatureView(
     name="driver_hourly_stats",
-    entities=["driver_id"],
-    ttl=Duration(seconds=86400 * 1),
-    features=[
-        Feature(name="conv_rate", dtype=ValueType.FLOAT),
-        Feature(name="acc_rate", dtype=ValueType.FLOAT),
-        Feature(name="avg_daily_trips", dtype=ValueType.INT64),
+    entities=[driver],
+    ttl=datetime.timedelta(seconds=86400 * 1),
+    schema=[
+        Field(name="conv_rate", dtype=PrimitiveFeastType.FLOAT32),
+        Field(name="acc_rate", dtype=PrimitiveFeastType.FLOAT32),
+        Field(name="avg_daily_trips", dtype=PrimitiveFeastType.INT32),
     ],
     online=True,
-    input=driver_hourly_stats,
+    source=driver_hourly_stats,
     tags={},
 )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as f:
     readme = f.read()
 
 INSTALL_REQUIRE = [
-    "feast>=0.17.0",
+    "feast>=0.26.0",
     "impyla[kerberos]>=0.15.0",
 ]
 
@@ -21,7 +21,7 @@ DEV_REQUIRE = [
 
 setup(
     name="feast-hive",
-    version="0.17.0",
+    version="0.26.0",
     author="Benn Ma",
     author_email="bennmsg@gmail.com",
     description="Hive support for Feast offline store",


### PR DESCRIPTION
I've made some changes to support `0.26.0` feast API.

* added features : https://docs.feast.dev/getting-started/concepts/dataset

Additionally, the test code was also modified according to the version.

patched some code according to [bigquery.py](https://github.com/feast-dev/feast/blob/master/sdk/python/feast/infra/offline_stores/bigquery.py) and [trino.py](https://github.com/feast-dev/feast/blob/master/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino.py)

#### Functionality Matrix

| Function | Hive |
| :-------------------------------- | :-- |
| `get_historical_features`         | yes |
| `pull_latest_from_table_or_query` | yes |
| `pull_all_from_table_or_query`    | yes |
| `offline_write_batch`             | no  |
| `write_logged_features`           | no  |